### PR TITLE
Update gradle build to use latest tools, check style and allow signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,48 @@ buildscript {
     repositories {
         mavenCentral()
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.11.+'
+        classpath 'com.android.tools.build:gradle:0.12.+'
     }
 }
 
 apply plugin: 'android'
+apply plugin: 'checkstyle'
 
 android {
-    compileSdkVersion 'android-19'
-    buildToolsVersion '20.0.0'
+    compileSdkVersion 'android-21'
+    buildToolsVersion '21.0.1'
+
+    sourceSets {
+        main {
+            manifest.srcFile 'src/main/AndroidManifest.xml'
+            java.srcDirs = ['src']
+            res.srcDirs = ['src/main/res']
+            assets.srcDirs = ['src/main/assets']
+        }
+    }
+
+    signingConfigs {
+        release
+    }
+
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
+}
+
+if (project.hasProperty('keyAlias')) {
+    android.signingConfigs.release.keyAlias = keyAlias
+}
+if (project.hasProperty('keyPassword')) {
+    android.signingConfigs.release.keyPassword = keyPassword
+}
+if (project.hasProperty('storeFile')) {
+    android.signingConfigs.release.storeFile = file(storeFile)
+}
+if (project.hasProperty('storePassword')) {
+    android.signingConfigs.release.storePassword = storePassword
 }


### PR DESCRIPTION
These changes update the gradle build to:
1. Use the most recent versions of the SDK platform and build tools
2. Add a style checker to the build process
3. Allow the apk being output to be signed

My personal favourite way to build and output a signed apk, which allows the build process to be scripted without having to save your keystore or keyalias passwords in plaintext, is like this:

```
./gradlew android:assembleRelease \                                                                                                                                                                                 
    -Pandroid.injected.signing.store.file=$KEYFILE \                                                                                                                                                                
    -Pandroid.injected.signing.store.password=$KEYFILE_PASS \                                                                                                                                                           
    -Pandroid.injected.signing.key.alias=$KEYALIAS \                                                                                                                                                               
    -Pandroid.injected.signing.key.password=$KEYALIAS_PASS
```
